### PR TITLE
Rect mixin correct mehod set

### DIFF
--- a/src/main/java/org/stjs/bridge/react/React.java
+++ b/src/main/java/org/stjs/bridge/react/React.java
@@ -934,26 +934,26 @@ public class React {
 		 * be traversed: fn will never be passed the container objects. If children is null or undefined returns null or undefined rather than an
 		 * empty object.
 		 */
-		public native <V> Map<?, V> map(Map<?, V> children, Function1<V, V> callback);
+		public static native <V> Map<?, V> map(Map<?, V> children, Function1<V, V> callback);
 
-		public native <V> Map<?, V> map(Map<?, V> children, Function1<V, V> callback, Context context);
+		public static native <V> Map<?, V> map(Map<?, V> children, Function1<V, V> callback, Context context);
 
 		/**
 		 * Like React.Children.map() but does not return an object.
 		 */
-		public native <V> void forEach(Map<?, V> children, Callback1<V> callback);
+		public static native <V> void forEach(Map<?, V> children, Callback1<V> callback);
 
-		public native <V> void forEach(Map<?, V> children, Callback1<V> callback, Context context);
+		public static native <V> void forEach(Map<?, V> children, Callback1<V> callback, Context context);
 
 		/**
 		 * Return the total number of components in children, equal to the number of times that a callback passed to map or forEach would be invoked.
 		 */
-		public native Integer count(Object children);
+		public static native Integer count(Object children);
 
 		/**
 		 * Return the only child in children. Throws otherwise.
 		 */
-		public native Object only(Object children);
+		public static native Object only(Object children);
 	}
 
 	//TODO :: finish signature

--- a/src/main/java/org/stjs/bridge/react/internal/ReactClassInterface.java
+++ b/src/main/java/org/stjs/bridge/react/internal/ReactClassInterface.java
@@ -4,27 +4,12 @@ import org.stjs.javascript.Map;
 import org.stjs.javascript.dom.Element;
 import org.stjs.javascript.functions.Callback0;
 
-abstract public class ReactClassInterface<P extends Props, S extends State> {
+abstract public class ReactClassInterface<P extends Props, S extends State> extends ReactClassStatefulInterface<P,S> implements ReactClassLifecycleInterface<P,S> {
 
 	/**
 	 * This concept is not documented yet
 	 */
 	protected Object context;
-
-	/**
-	 * Hold the reference to the elements that have a "ref" key
-	 */
-	public Map<String, ReactComponent> refs;
-
-	/**
-	 * The properties of the react component This can be seen as the constructor of a class
-	 */
-	public P props;
-
-	/**
-	 * The state of the react component This can be seen as the protected fields of a class
-	 */
-	protected S state;
 
 	/**
 	 * Definition of context types for this component.
@@ -43,90 +28,25 @@ abstract public class ReactClassInterface<P extends Props, S extends State> {
 	 */
 	public native Context getChildContext();
 
-	/**
-	 * Invoked when the component is initially created and about to be mounted. This may have side effects, but any
-	 * external subscriptions or data created by this method must be cleaned up in `componentWillUnmount`.
-	 */
+	@Override
 	public native void componentWillMount();
 
-	/**
-	 * Invoked when the component has been mounted and has a DOM representation. However, there is no guarantee that the
-	 * DOM node is in the document.
-	 *
-	 * Use this as an opportunity to operate on the DOM when the component has been mounted (initialized and rendered)
-	 * for the first time.
-	 *
-	 * @param element
-	 *            rootNode DOM element representing the component.
-	 */
+	@Override
 	public native void componentDidMount(Element element);
 
-	/**
-	 * Invoked before the component receives new props.
-	 *
-	 * Use this as an opportunity to react to a prop transition by updating the state using `this.setState`. Current
-	 * props are accessed via `this.props`.
-	 *
-	 * componentWillReceiveProps: function(nextProps, nextContext) { this.setState({ likesIncreasing:
-	 * nextProps.likeCount > this.props.likeCount }); }
-	 *
-	 * NOTE: There is no equivalent `componentWillReceiveState`. An incoming prop transition may cause a state change,
-	 * but the opposite is not true. If you need it, you are probably looking for `componentWillUpdate`.
-	 */
+	@Override
 	public native void componentWillReceiveProps(P nextProps);
 
-	/**
-	 * Invoked while deciding if the component should be updated as a result of receiving new props, state and/or
-	 * context.
-	 *
-	 * Use this as an opportunity to `return false` when you're certain that the transition to the new
-	 * props/state/context will not require a component update.
-	 *
-	 * shouldComponentUpdate: function(nextProps, nextState, nextContext) { return !equal(nextProps, this.props) ||
-	 * !equal(nextState, this.state) || !equal(nextContext, this.context); }
-	 *
-	 * @param nextProps
-	 * @param nextState
-	 * @param nextContext
-	 * @return True if the component should update.
-	 */
+	@Override
 	public native boolean shouldComponentUpdate(P nextProps, S nextState, Context nextContext);
 
-	/**
-	 * Invoked when the component is about to update due to a transition from `this.props`, `this.state` and
-	 * `this.context` to `nextProps`, `nextState` and `nextContext`.
-	 *
-	 * Use this as an opportunity to perform preparation before an update occurs.
-	 *
-	 * NOTE: You **cannot** use `this.setState()` in this method.
-	 *
-	 * @param nextProps
-	 * @param nextState
-	 * @param nextContext
-	 * @param transaction
-	 */
+	@Override
 	public native boolean componentWillUpdate(P nextProps, S nextState, Context nextContext, ReactReconcileTransaction transaction);
 
-	/**
-	 * Invoked when the component's DOM representation has been updated.
-	 *
-	 * Use this as an opportunity to operate on the DOM when the component has been updated.
-	 *
-	 * @param prevProps
-	 * @param prevState
-	 * @param prevContext
-	 * @param rootNode
-	 *            DOM element representing the component.
-	 */
+	@Override
 	public native void componentDidUpdate(P prevProps, S prevState, Context prevContext, Element rootNode);
 
-	/**
-	 * Invoked when the component is about to be removed from its parent and have its DOM representation destroyed.
-	 *
-	 * Use this as an opportunity to deallocate any external resources.
-	 *
-	 * NOTE: There is no `componentDidUnmount` since your component will have been destroyed by that point.
-	 */
+	@Override
 	public native void componentWillUnmount();
 
 	/**
@@ -148,33 +68,6 @@ abstract public class ReactClassInterface<P extends Props, S extends State> {
 	public abstract ReactElement<?> render();
 
 	// BEGIN ReactComponent
-	/**
-	 * Sets a subset of the state. Always use this to mutate state. You should treat `this.state` as immutable.
-	 *
-	 * There is no guarantee that `this.state` will be immediately updated, so accessing `this.state` after calling this
-	 * method may return the old value.
-	 *
-	 * There is no guarantee that calls to `setState` will run synchronously, as they may eventually be batched
-	 * together. You can provide an optional callback that will be executed when the call to setState is actually
-	 * completed.
-	 *
-	 * When a function is provided to setState, it will be called at some point in the future (not synchronously). It
-	 * will be called with the up to date component arguments (state, props, context). These values can be different
-	 * from this.* because your function may be called after receiveProps but before shouldComponentUpdate, and this new
-	 * state, props, and context will not yet be assigned to this.
-	 *
-	 * @param partialState
-	 *            Next partial state or function to produce next partial state to be merged with current state.
-	 * @param callback
-	 *            Called after state is updated.
-	 */
-	protected void setState(S partialState, Callback0 callback) {
-		// Will be replaced on runtime
-	}
-
-	protected void setState(S partialState) {
-		// Will be replaced on runtime
-	}
 
 	/**
 	 * Forces an update. This should only be invoked when it is known with certainty that we are **not** in a DOM

--- a/src/main/java/org/stjs/bridge/react/internal/ReactClassLifecycleInterface.java
+++ b/src/main/java/org/stjs/bridge/react/internal/ReactClassLifecycleInterface.java
@@ -1,0 +1,96 @@
+package org.stjs.bridge.react.internal;
+
+import org.stjs.javascript.dom.Element;
+
+/**
+ * The interface to represent all React class lifecycle methods.
+ * @param <P> the properties class
+ * @param <S> the state classc
+ */
+public interface ReactClassLifecycleInterface<P extends Props, S extends State> {
+	/**
+	 * Invoked when the component is initially created and about to be mounted. This may have side effects, but any
+	 * external subscriptions or data created by this method must be cleaned up in `componentWillUnmount`.
+	 */
+	void componentWillMount();
+
+	/**
+	 * Invoked when the component has been mounted and has a DOM representation. However, there is no guarantee that the
+	 * DOM node is in the document.
+	 *
+	 * Use this as an opportunity to operate on the DOM when the component has been mounted (initialized and rendered)
+	 * for the first time.
+	 *
+	 * @param element
+	 *            rootNode DOM element representing the component.
+	 */
+	void componentDidMount(Element element);
+
+	/**
+	 * Invoked before the component receives new props.
+	 *
+	 * Use this as an opportunity to react to a prop transition by updating the state using `this.setState`. Current
+	 * props are accessed via `this.props`.
+	 *
+	 * componentWillReceiveProps: function(nextProps, nextContext) { this.setState({ likesIncreasing:
+	 * nextProps.likeCount > this.props.likeCount }); }
+	 *
+	 * NOTE: There is no equivalent `componentWillReceiveState`. An incoming prop transition may cause a state change,
+	 * but the opposite is not true. If you need it, you are probably looking for `componentWillUpdate`.
+	 */
+	void componentWillReceiveProps(P nextProps);
+
+	/**
+	 * Invoked while deciding if the component should be updated as a result of receiving new props, state and/or
+	 * context.
+	 *
+	 * Use this as an opportunity to `return false` when you're certain that the transition to the new
+	 * props/state/context will not require a component update.
+	 *
+	 * shouldComponentUpdate: function(nextProps, nextState, nextContext) { return !equal(nextProps, this.props) ||
+	 * !equal(nextState, this.state) || !equal(nextContext, this.context); }
+	 *
+	 * @param nextProps
+	 * @param nextState
+	 * @param nextContext
+	 * @return True if the component should update.
+	 */
+	boolean shouldComponentUpdate(P nextProps, S nextState, Context nextContext);
+
+	/**
+	 * Invoked when the component is about to update due to a transition from `this.props`, `this.state` and
+	 * `this.context` to `nextProps`, `nextState` and `nextContext`.
+	 *
+	 * Use this as an opportunity to perform preparation before an update occurs.
+	 *
+	 * NOTE: You **cannot** use `this.setState()` in this method.
+	 *
+	 * @param nextProps
+	 * @param nextState
+	 * @param nextContext
+	 * @param transaction
+	 */
+	boolean componentWillUpdate(P nextProps, S nextState, Context nextContext, ReactReconcileTransaction transaction);
+
+	/**
+	 * Invoked when the component's DOM representation has been updated.
+	 *
+	 * Use this as an opportunity to operate on the DOM when the component has been updated.
+	 *
+	 * @param prevProps
+	 * @param prevState
+	 * @param prevContext
+	 * @param rootNode
+	 *            DOM element representing the component.
+	 */
+	void componentDidUpdate(P prevProps, S prevState, Context prevContext, Element rootNode);
+
+	/**
+	 * Invoked when the component is about to be removed from its parent and have its DOM representation destroyed.
+	 *
+	 * Use this as an opportunity to deallocate any external resources.
+	 *
+	 * NOTE: There is no `componentDidUnmount` since your component will have been destroyed by that point.
+	 */
+	void componentWillUnmount();
+}

--- a/src/main/java/org/stjs/bridge/react/internal/ReactClassStatefulInterface.java
+++ b/src/main/java/org/stjs/bridge/react/internal/ReactClassStatefulInterface.java
@@ -1,0 +1,52 @@
+package org.stjs.bridge.react.internal;
+
+import org.stjs.javascript.Map;
+import org.stjs.javascript.functions.Callback0;
+
+/**
+ * The statefull react class representation with all related methods.
+ * @param <P>
+ * @param <S>
+ */
+public class ReactClassStatefulInterface<P extends Props, S extends State> {
+	/**
+	 * Hold the reference to the elements that have a "ref" key
+	 */
+	public Map<String, ReactComponent> refs;
+	/**
+	 * The properties of the react component This can be seen as the constructor of a class
+	 */
+	public P props;
+	/**
+	 * The state of the react component This can be seen as the protected fields of a class
+	 */
+	protected S state;
+
+	/**
+	 * Sets a subset of the state. Always use this to mutate state. You should treat `this.state` as immutable.
+	 *
+	 * There is no guarantee that `this.state` will be immediately updated, so accessing `this.state` after calling this
+	 * method may return the old value.
+	 *
+	 * There is no guarantee that calls to `setState` will run synchronously, as they may eventually be batched
+	 * together. You can provide an optional callback that will be executed when the call to setState is actually
+	 * completed.
+	 *
+	 * When a function is provided to setState, it will be called at some point in the future (not synchronously). It
+	 * will be called with the up to date component arguments (state, props, context). These values can be different
+	 * from this.* because your function may be called after receiveProps but before shouldComponentUpdate, and this new
+	 * state, props, and context will not yet be assigned to this.
+	 *
+	 * @param partialState
+	 *            Next partial state or function to produce next partial state to be merged with current state.
+	 * @param callback
+	 *            Called after state is updated.
+	 */
+	protected void setState(S partialState, Callback0 callback) {
+		// Will be replaced on runtime
+	}
+
+	protected void setState(S partialState) {
+		// Will be replaced on runtime
+	}
+}

--- a/src/main/java/org/stjs/bridge/react/internal/ReactMixin.java
+++ b/src/main/java/org/stjs/bridge/react/internal/ReactMixin.java
@@ -1,5 +1,43 @@
 package org.stjs.bridge.react.internal;
 
+import org.stjs.javascript.dom.Element;
+
 @IsReactMixin
-public abstract class ReactMixin<P extends Props, S extends State> extends ReactClassInterface<P, S> {
+public abstract class ReactMixin<P extends Props, S extends State> extends ReactClassStatefulInterface<P, S>
+		implements ReactClassLifecycleInterface<P, S> {
+
+	@Override
+	public void componentWillMount() {
+
+	}
+
+	@Override
+	public void componentDidMount(Element element) {
+
+	}
+
+	@Override
+	public void componentWillReceiveProps(P nextProps) {
+
+	}
+
+	@Override
+	public boolean shouldComponentUpdate(P nextProps, S nextState, Context nextContext) {
+		return false;
+	}
+
+	@Override
+	public boolean componentWillUpdate(P nextProps, S nextState, Context nextContext, ReactReconcileTransaction transaction) {
+		return false;
+	}
+
+	@Override
+	public void componentDidUpdate(P prevProps, S prevState, Context prevContext, Element rootNode) {
+
+	}
+
+	@Override
+	public void componentWillUnmount() {
+
+	}
 }


### PR DESCRIPTION
At the moment the ReactMixin class extends ReactClassInterface. Unfortunately not all the methods are allowed for mixins by React (e.g. render method). Only lifecycle methods are allowed. For that reason the ReactClassInterface was split to provide stateful functionality to be able to use it in mixin and also a lifecycle interfase was extracted.
